### PR TITLE
Fix bug in range bin migration modeling term in script

### DIFF
--- a/radar_modeling/range_bin_migration/rangeBinMigrationInducedPhaseJumps_radarBaseBandModel.py
+++ b/radar_modeling/range_bin_migration/rangeBinMigrationInducedPhaseJumps_radarBaseBandModel.py
@@ -90,10 +90,10 @@ objectVelocityInt = np.int(objectVelocityBin)
 dopplerSignal = np.exp(1j*((2*np.pi*objectVelocityBin)/numChirps)*np.arange(numChirps))
 
 """ Range Bin migration term"""
-# rangeBinMigration = \
-#     np.exp(1j*2*np.pi*chirpSlope*(2*objectVelocity_mps/lightSpeed)*interRampTime*adcSamplingTime*np.arange(numSamples)[:,None]*np.arange(numChirps)[None,:])
+rangeBinMigration = \
+    np.exp(1j*2*np.pi*chirpSlope*(2*objectVelocity_mps/lightSpeed)*interRampTime*adcSamplingTime*np.arange(numSamples)[:,None]*np.arange(numChirps)[None,:])
 
-rangeBinMigration = np.exp(1j*((2*np.pi)/(binsMoved*numFFTBins))*np.arange(numSamples)[:,None]*np.arange(numChirps)[None,:])
+# rangeBinMigration = np.exp(1j*((2*np.pi)/(binsMoved*numFFTBins))*np.arange(numSamples)[:,None]*np.arange(numChirps)[None,:])
 
 
 radarSignal = rangeSignal[:,None] * dopplerSignal[None,:] * rangeBinMigration


### PR DESCRIPTION
In this commit, I have fixed a bug in modeling the range bin migration
term in the script 'rangeBinMigrationInducedPhaseJumps_radarBaseBandModel.py'. The correct modeling term was already present but it was commented out. In its place, I had added another term. But this was incorrect. So I have reverted back to the correct range bin migration modeling term. With this change, all is working fine now. I see phase jumps (~pi radians) occuring whenever there is a range bin migration and this is happening for all the bandwidths (500MHz, 1GHz, 4GHz). This measn that all is fine.

Signed-off-by: Sai Gunaranjan Pelluri <saigunaranjanpelluri@gmail.com>