### PR TITLE
Ensure phase shifter LUT is modulo 360 degrees

### DIFF
--- a/radar_modeling/DopplerDivisionMultiplexing/DDMA_monteCarlo.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/DDMA_monteCarlo.py
@@ -97,6 +97,8 @@ phaseStepPerRamp_rad = (phaseStepPerRamp_deg/360)*2*np.pi
 phaseShifterCodes = DNL*np.arange(numPhaseCodes)
 phaseShifterNoise = np.random.uniform(-DNL/2, DNL/2, numPhaseCodes)
 phaseShifterCodes_withNoise = phaseShifterCodes + phaseShifterNoise
+""" Ensure that the phase shifter LUT is without any bias and is from 0 to 360 degrees"""
+phaseShifterCodes_withNoise = np.mod(phaseShifterCodes_withNoise,360)
 
 
 """ RF parameters """

--- a/radar_modeling/DopplerDivisionMultiplexing/DDMA_multiDoppler_vectorized.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/DDMA_multiDoppler_vectorized.py
@@ -158,6 +158,8 @@ phaseStepPerRamp_rad = (phaseStepPerRamp_deg/360)*2*np.pi
 phaseShifterCodes = DNL*np.arange(numPhaseCodes)
 phaseShifterNoise = np.random.uniform(-DNL/2, DNL/2, numPhaseCodes)
 phaseShifterCodes_withNoise = phaseShifterCodes + phaseShifterNoise
+""" Ensure that the phase shifter LUT is without any bias and is from 0 to 360 degrees"""
+phaseShifterCodes_withNoise = np.mod(phaseShifterCodes_withNoise,360)
 
 """ NOT USING THE BELOW QUADRATIC PHASE in this DDMA MIMO scheme
 

--- a/radar_modeling/DopplerDivisionMultiplexing/DDMA_singleDoppler.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/DDMA_singleDoppler.py
@@ -149,6 +149,8 @@ phaseStepPerRamp_rad = (phaseStepPerRamp_deg/360)*2*np.pi
 phaseShifterCodes = DNL*np.arange(numPhaseCodes)
 phaseShifterNoise = np.random.uniform(-DNL/2, DNL/2, numPhaseCodes)
 phaseShifterCodes_withNoise = phaseShifterCodes + phaseShifterNoise
+""" Ensure that the phase shifter LUT is without any bias and is from 0 to 360 degrees"""
+phaseShifterCodes_withNoise = np.mod(phaseShifterCodes_withNoise,360)
 
 """ NOT USING THE BELOW QUADRATIC PHASE in this DDMA MIMO scheme
 

--- a/radar_modeling/DopplerDivisionMultiplexing/DDMA_singleDoppler_simpleCase.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/DDMA_singleDoppler_simpleCase.py
@@ -144,6 +144,8 @@ phaseStepPerRamp_rad = (phaseStepPerRamp_deg/360)*2*np.pi
 phaseShifterCodes = DNL*np.arange(numPhaseCodes)
 phaseShifterNoise = np.random.uniform(-DNL/2, DNL/2, numPhaseCodes)
 phaseShifterCodes_withNoise = phaseShifterCodes + phaseShifterNoise
+""" Ensure that the phase shifter LUT is without any bias and is from 0 to 360 degrees"""
+phaseShifterCodes_withNoise = np.mod(phaseShifterCodes_withNoise,360)
 
 """ NOT USING THE BELOW QUADRATIC PHASE in this DDMA MIMO scheme
 

--- a/radar_modeling/DopplerDivisionMultiplexing/phaseShifterPeriodicity.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/phaseShifterPeriodicity.py
@@ -47,6 +47,8 @@ numRamps = 140
 phaseShifterCodes = DNL*np.arange(numPhaseCodes)
 phaseShifterNoise = np.random.uniform(-DNL/2, DNL/2, numPhaseCodes)
 phaseShifterCodes_withNoise = phaseShifterCodes + phaseShifterNoise
+""" Ensure that the phase shifter LUT is without any bias and is from 0 to 360 degrees"""
+phaseShifterCodes_withNoise = np.mod(phaseShifterCodes_withNoise,360)
 
 """ A small quadratic term is added to the linear phase term to break the periodicity.
 The strength of the quadratic term is controlled by the alpha parameter. If alpha is large,


### PR DESCRIPTION
In this branch, I have made a minor code change to the DDMA scripts. The phase shifter LUT might not always be in the range from 0 to 360 degrees. It could be from say 160 degrees to 530 degrees and so when I take the closest value of the phase shifter code to say 0 degrees, I will end up picking 160. But this is wrong. I need to bring the phase shifter LUT modulo 360 degrees before searching for the closest code. For now, in my modeling, this is not very significant since I always generate the LUT from 0 to 360 degrees but in general, the phase shifter LUT might have a bias and might be unwrapped and could start from a high value and also go to a higher value.

Signed-off-by: Sai Gunaranjan Pelluri <saigunaranjanpelluri@gmail.com>