### PR TITLE
Fix bug in generating target range

### DIFF
--- a/compression_algorithms/continental_compression/compression_rfft_analysis.py
+++ b/compression_algorithms/continental_compression/compression_rfft_analysis.py
@@ -18,8 +18,8 @@ from conti_compression import ContiCompression
 
 
 plt.close('all')
-np.random.seed(3) # 3
 
+# np.random.seed(3)
 
 
 """ Chirp Parameters"""
@@ -27,7 +27,7 @@ numTx_simult = 4
 numRx = 4 # Increased number of Rxs from 4 to 32 to get a smoother averaging of signal/noise power
 numRamps = 512
 numSamp = 2048 # Number of ADC time domain samples
-numSampPostRfft = 50#numSamp//2
+numSampPostRfft = 3 # Processing only 3 range bins. Since others are of no use. Saves compute.
 lightSpeed = 3e8
 numDoppFFT = 512#2048
 chirpBW = 1e9 # Hz
@@ -71,7 +71,7 @@ thermalNoiseFloorPostDFFT = noiseFloor_perBin - 10*np.log10(numRamps)
 
 
 """ Target definition"""
-objectRange = np.random.uniform(10,maxRange-10) # 60.3 # m
+objectRange = 1*rangeRes # Fixing the taregt range bin to range bin = 1 out of the total 3 range bins for processing
 objectVelocity_mps = 0
 objectAzAngle_deg = np.random.uniform(-50,50)
 objectAzAngle_rad = (objectAzAngle_deg/360) * (2*np.pi)
@@ -200,8 +200,8 @@ for ele in range(numCases):
 
 
 
-    """ With Compression/decompression"""
-    signal_rfftQuantReal = np.real(signal_rfftQuant).astype(np.uint32)
+    """ With Conti Compression/decompression"""
+    signal_rfftQuantReal = np.real(signal_rfftQuant).astype(np.uint32) # required in 2's complement format and hence typecast as uint
     signal_rfftQuantImag = np.imag(signal_rfftQuant).astype(np.uint32)
 
     signal_rfftQuantRealdecomp = np.zeros((numRamps,numRx,numSampPostRfft),dtype=np.uint32)

--- a/radar_modeling/DopplerDivisionMultiplexing/DDMA_phaseshifter_noise_analysis.py
+++ b/radar_modeling/DopplerDivisionMultiplexing/DDMA_phaseshifter_noise_analysis.py
@@ -43,14 +43,16 @@ import matplotlib.pyplot as plt
 
 
 plt.close('all')
-np.random.seed(3) # 3
+
+# np.random.seed(3)
+
 
 """ Chirp Parameters"""
 numTx_simult = 4
 numRx = 32 # Increased number of Rxs from 4 to 32 to get a smoother averaging of signal/noise power
 numRamps = 512
 numSamp = 2048 # Number of ADC time domain samples
-numSampPostRfft = numSamp//2
+numSampPostRfft = 3 # Processing only 3 range bins. Since others are of no use. Saves compute.
 lightSpeed = 3e8
 numDoppFFT = 512#2048
 chirpBW = 1e9 # Hz
@@ -91,7 +93,7 @@ thermalNoiseFloorPostDFFT = noiseFloor_perBin - 10*np.log10(numRamps)
 
 
 """ Target definition"""
-objectRange = np.random.uniform(10,maxRange-10) # 60.3 # m
+objectRange = 1*rangeRes # Fixing the taregt range bin to range bin = 1 out of the total 3 range bins for processing
 objectVelocity_mps = 0
 objectAzAngle_deg = np.random.uniform(-50,50)
 objectAzAngle_rad = (objectAzAngle_deg/360) * (2*np.pi)


### PR DESCRIPTION
In this commit, I have fixed a bug in generating the target range. Due to this bug, sometimes, the target range was coming out as negative. Since we throw out the negative frequencies in range, the signal was getting lost and some random incorrect range bin was getting sampled and this was leading to some weird results. This was the reason, the output was very dependent on the seed programmed. For any random run, sometimes, it was generating a negative range. Now, I have fixed the target to range to 1*rangeRes and made the max range bins post performing RFFT to just 3 bins. This is because, all other range bins are just noise and I dont need to process the other range bins. The compression analysis needs to be done only on the target range bin and hence we can reduce the compute by limiting the processing to just the target range bin. But I have given a further processing of 2 range bins.