### PR TITLE
Improve spur levels in Conti compression scheme

### DIFF
--- a/compression_algorithms/continental_compression/compression_rfft_analysis.py
+++ b/compression_algorithms/continental_compression/compression_rfft_analysis.py
@@ -72,7 +72,7 @@ thermalNoiseFloorPostDFFT = noiseFloor_perBin - 10*np.log10(numRamps)
 
 """ Target definition"""
 objectRange = 1*rangeRes # Fixing the taregt range bin to range bin = 1 out of the total 3 range bins for processing
-objectVelocity_mps = 0
+objectVelocity_mps = 25*velocityRes
 objectAzAngle_deg = np.random.uniform(-50,50)
 objectAzAngle_rad = (objectAzAngle_deg/360) * (2*np.pi)
 
@@ -226,7 +226,7 @@ for ele in range(numCases):
     chirpSamp_givenRangeBin_decomp = chirpSamp_givenRangeBin_decomp*binMigrationPhasorCorrTerm[:,None]
     chirpSamp_givenRangeBin_decomp = chirpSamp_givenRangeBin_decomp*rbmModulationCorrectionTerm[:,None]
 
-    signalWindoweddecomp = chirpSamp_givenRangeBin_decomp
+    signalWindoweddecomp = chirpSamp_givenRangeBin_decomp#*np.hanning(numRamps)[:,None]
     signalFFTdecomp = np.fft.fft(signalWindoweddecomp, axis=0, n = numDoppFFT)/numRamps
     signalFFTShiftdecomp = signalFFTdecomp
     signalFFTShiftSpectrumdecomp = np.abs(signalFFTShiftdecomp)**2

--- a/compression_algorithms/continental_compression/conti_compression.py
+++ b/compression_algorithms/continental_compression/conti_compression.py
@@ -166,6 +166,9 @@ class ContiCompression:
 
             self.decompressedRxSamples[self.numRealRxChannels-ele3-1] = signExtensionPart | (channelMantissaRecon << \
                                                            (self.signalBitwidth-self.blockShiftReconstr-self.numMantissaBits))
+            """ The below step is performed to reduce the spurs due to quantization.
+            Instead of filling the bits post mantissa bits with all 0's, we fill it with 1 followed by zeros. This reduces the spurs"""
+            self.decompressedRxSamples[self.numRealRxChannels-ele3-1] |= (1 << (self.signalBitwidth-self.blockShiftReconstr-self.numMantissaBits-1))
 
 
         self.rxSamplesRealRecon = self.decompressedRxSamples[0::2] # uint32


### PR DESCRIPTION
Conti scheme suffers from larger precision loss at higher SNRs. So, in general, at higher SNRs, the quantization loss is higher and if we simply pad zeros after the mantissa bits, then we incur a larger loss and this error can get periodic resulting in spurs. In their patent, Conti suggests a way to reduce these spurs. Instead of simply padding zeros post the mantissa bits, we replace it with 1 followed by zeros. This way, we incur a lower loss on average since we take a middle ground. The bits post the mantissa could vary from all 0's (lowest value) to all 1's (highest value). So, we replace it with 1 followed by zeros which is like the midpoint. This ensures we reduce the error on "average" and reduces the spurs levels significantly. Conti suggests adding a random number ranging from 0 to mantissa LSB. But for now, I have done a soft rounding.

I have made one more change in this commit. For checking the compression analysis, I was dialling 0 Doppler. But this was somehow not showing up all issues like spurs, etc. So, now, I have given a small velocity to the targets in the simulations.